### PR TITLE
Fix padding in tensor packing

### DIFF
--- a/optiacts/bit_compress.py
+++ b/optiacts/bit_compress.py
@@ -15,7 +15,7 @@ def to_bool_tensor(data, shape) -> t.Tensor:
 def from_bool_tensor(other: t.Tensor) -> t.Tensor:
     other = other.view(-1)
     if other.numel() % 8 != 0:
-        other = t.constant_pad_nd(other, (0, 8 - other.numel() % 8), 0)
+        other = t.constant_pad_nd(other, (0, (8 - other.numel() % 8) % 8), 0)
     size = len(other) // 8
     data = (
         other.reshape(size, 8).byte() << t.arange(8, device=other.device, dtype=t.uint8)


### PR DESCRIPTION
If "other" size is already dividable by 8 (e.g. 64), original code will pad it by 8: 8 - 64 % 8 = 8 - 0 = 8 So we need one more "mod"